### PR TITLE
Fix for CSS and update source-map.

### DIFF
--- a/lib/generate.js
+++ b/lib/generate.js
@@ -44,7 +44,7 @@ function generateCss(sourcePath, fileContent) {
 
     for (var key in ast) {
       if (key === 'position' || !ast[key]) {
-        break;
+        continue;
       }
       if (Object.prototype.toString.call(ast[key]) === '[object Object]') {
         registerTokens(ast[key]);

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "acorn": "^5.0.3",
     "css": "^2.2.1",
     "normalize-path": "^2.1.1",
-    "source-map": "^0.5.6",
+    "source-map": "^0.6.0",
     "through2": "^2.0.3"
   },
   "devDependencies": {


### PR DESCRIPTION
This updates the source-map to ~0.6.0, the same version used by
gulp-sourcemaps.  Also fix processing of CSS sourcemaps by skipping an
entry when `key === 'position' || !ast[key]` instead of aborting
processing.  This matches how it is done in the deprecated option of
gulp-sourcemaps.