### PR TITLE
Support ES2018 syntax by upgrading acorn

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+test/fixtures

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -6,7 +6,10 @@ var SourceMapGenerator = require('source-map').SourceMapGenerator;
 
 function generateJs(sourcePath, fileContent) {
   var generator = new SourceMapGenerator({ file: sourcePath });
-  var tokenizer = acorn.tokenizer(fileContent, { allowHashBang: true, locations: true });
+  var tokenizer = acorn.tokenizer(fileContent, {
+    allowHashBang: true,
+    locations: true,
+  });
 
   while (true) {
     var token = tokenizer.getToken();

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "coveralls": "npm run cover && istanbul-coveralls"
   },
   "dependencies": {
-    "acorn": "^5.0.3",
+    "acorn": "^6.1.1",
     "css": "^2.2.1",
     "normalize-path": "^2.1.1",
     "source-map": "^0.6.0",

--- a/test/fixtures/es2018.js
+++ b/test/fixtures/es2018.js
@@ -1,0 +1,25 @@
+const justA = { a: 1 };
+// Object Spread
+const AandB = { ...justA, b: 2 };
+// Object Rest
+const { a: _, ...justB } = AandB;
+
+// RegExp unicode ("u") flag
+Boolean(/abc/u.exec("abc"));
+
+// Promise.prototype.finally()
+Promise.resolve().finally(() => {
+    // at last!
+});
+
+// RegExp "s" flag
+Boolean(/.{3}/s.exec("a\nb"));
+
+// Regex Lookbehind Assertions
+Boolean(/(?<=\$)\d+/.exec("$42"));
+
+// Tagged template literal revision
+String.raw`\unicode`; // Good
+
+// RegExp named capture groups
+/(?<year1>\d{4})-(?<year2>\d{4})/.exec("1992-2019");

--- a/test/index.js
+++ b/test/index.js
@@ -18,6 +18,7 @@ var concat = miss.concat;
 
 var jsContent = fs.readFileSync(path.join(__dirname, 'fixtures/helloworld.js'));
 var jsHashBangContent = fs.readFileSync(path.join(__dirname, 'fixtures/helloworld.bin.js'));
+var jsES2018Content = fs.readFileSync(path.join(__dirname, 'fixtures/es2018.js'));
 var cssContent = fs.readFileSync(path.join(__dirname, 'fixtures/helloworld.css'));
 
 function makeFile() {
@@ -155,6 +156,29 @@ describe('identityMap', function() {
       expect(sourcemap.sourcesContent[0]).toEqual(jsHashBangContent);
       expect(sourcemap.names).toEqual(['helloWorld', 'console','log']);
       expect(sourcemap.mappings).toEqual(';AACA,YAAY;;AAEZ,SAASA,UAAU,CAAC,EAAE;EACpBC,OAAO,CAACC,GAAG,CAAC,cAAc,CAAC;AAC7B');
+    }
+
+    pipe([
+      from.obj([file]),
+      identityMap(),
+      concat(assert),
+    ], done);
+  });
+
+  it('adds a valid sourcemap for JS with ES2018 syntax', function(done) {
+    var file = makeFile();
+    file.contents = jsES2018Content;
+
+    function assert(files) {
+      expect(files.length).toEqual(1);
+
+      var sourcemap = files[0].sourceMap;
+      expect(sourcemap).toExist();
+      expect(sourcemap.version).toEqual('3');
+      expect(sourcemap.sources[0]).toBe('helloworld.js');
+      expect(sourcemap.sourcesContent[0]).toEqual(jsES2018Content);
+      expect(sourcemap.names).toEqual(['justA', 'a', 'AandB', 'b', '_', 'justB', 'Boolean', 'exec', 'Promise', 'resolve', 'String', 'raw']);
+      expect(sourcemap.mappings).toBe('AAAA,MAAMA,MAAM,EAAE,EAAEC,CAAC,EAAE,EAAE,CAAC;;AAEtB,MAAMC,MAAM,EAAE,EAAE,GAAGF,KAAK,EAAEG,CAAC,EAAE,EAAE,CAAC;;AAEhC,MAAM,EAAEF,CAAC,EAAEG,CAAC,EAAE,GAAGC,MAAM,EAAE,EAAEH,KAAK;;;AAGhCI,OAAO,CAAC,MAAM,CAACC,IAAI,CAAC,KAAK,CAAC,CAAC;;;AAG3BC,OAAO,CAACC,OAAO,CAAC,CAAC,CAAC,OAAO,CAAC,CAAC,EAAE,GAAG;;AAEhC,CAAC,CAAC;;;AAGFH,OAAO,CAAC,OAAO,CAACC,IAAI,CAAC,MAAM,CAAC,CAAC;;;AAG7BD,OAAO,CAAC,YAAY,CAACC,IAAI,CAAC,KAAK,CAAC,CAAC;;;AAGjCG,MAAM,CAACC,GAAG,CAAC,QAAQ,CAAC;;;AAGpB,iCAAiC,CAACJ,IAAI,CAAC,WAAW,CAAC');
     }
 
     pipe([


### PR DESCRIPTION
In order to provide identity sourcemaps for JavaScript with ES2018 syntax it's
necessary to update the parser.

This PR bumps the major version of acorn from 5 to 6 to achieve this.

The acorn release notes for major version 6 are [here](https://github.com/acornjs/acorn/releases/tag/6.0.0). In particular the breaking changes listed are:

> ### Breaking changes
>
> The default value of the `ecmaVersion` option is now 9 (2018).
>
> Plugins work differently, and will have to be rewritten to work with this version.
>
> The loose parser and walker have been moved into separate packages (`acorn-loose` and `acorn-walk`)

I don't think these pose a problem here.

Also included is a test fixture that fails without the changes and some tweaks
to pass the lint checks.