### PR TITLE
Bump PostCSS to 8.3, resolving CVE-2021-23368

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "acorn": "^6.4.1",
     "normalize-path": "^3.0.0",
-    "postcss": "^8.3.0",
+    "postcss": "^8.4.38",
     "source-map": "^0.6.0",
     "through2": "^3.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "acorn": "^6.4.1",
     "normalize-path": "^3.0.0",
-    "postcss": "^7.0.16",
+    "postcss": "^8.3.0",
     "source-map": "^0.6.0",
     "through2": "^3.0.1"
   },


### PR DESCRIPTION
Fixes PostCSS ReDoS vulnerability. See https://www.npmjs.com/advisories/1693

All tests run using `npm run test` pass. At a glance, it doesn't look like there are any relevant breaking changes in the [PostCSS 8.0.0 release notes](https://github.com/postcss/postcss/releases/tag/8.0.0).